### PR TITLE
Add MGATHER.CAS atomic compare-and-swap gather instruction

### DIFF
--- a/docs/isa/blockIntro/tma_block/header.md
+++ b/docs/isa/blockIntro/tma_block/header.md
@@ -58,7 +58,8 @@ Among them, the function field is used to encode specific TileOp information. Th
 | 5 | [MSCATTER](../../header/tileblock/MSCATTER.md) | Store the data in the Tile register into discrete memory space.  |
 | 6 | [MGATHER.MASK](../../header/tileblock/MGATHER.MASK.md) | Masked memory gather. Reads only lanes whose mask bit is set. |
 | 7 | [MSCATTER.MASK](../../header/tileblock/MSCATTER.MASK.md) | Masked memory scatter. Writes only lanes whose mask bit is set. |
-| 8-31 | Temporarily reserved |
+| 8 | [MGATHER.CAS](../../header/tileblock/MGATHER.CAS.md) | Atomic compare-and-swap gather. Per-element atomic CAS from memory to Tile. |
+| 9-31 | Temporarily reserved |
 
 The DataType field is encoded as follows:
 

--- a/docs/isa/header/tileblock/MGATHER.CAS.md
+++ b/docs/isa/header/tileblock/MGATHER.CAS.md
@@ -1,0 +1,90 @@
+# MGATHER.CAS
+
+## Overview
+
+**Atomic Compare-and-Swap Gather from Memory to Tile**
+
+`MGATHER.CAS` extends `MGATHER` with a per-element atomic compare-and-swap
+operation. For each active element, the instruction atomically compares the
+value in memory against an expected value from `SrcTile1`; if they match,
+the memory location is updated with a desired value from `SrcTile2`. The
+old value at the memory location is always written to the destination Tile.
+
+Only the `[0, validRow) x [0, validCol)` region participates in the CAS
+operation. The rest of the destination Tile is filled with `PadValue`.
+
+Compare and swap element types must match `DataType`. The offset Tile element
+type is independent and may be `u16`, `u32`, or `u64`.
+
+## Assembly syntax
+
+```asm
+MGATHER.CAS <LB0:validCol, LB1:validRow, LB2:Col, DataType, PadValue>,
+           SrcTile0<.reuse>, SrcTile1<.reuse>, SrcTile2<.reuse>,
+           [RegSrc], ->DstTile<Size>
+```
+
+## Parameters
+
+| Parameter | Description | Optional |
+|-----------|-------------|----------|
+| **validCol** | Number of valid columns in all source Tiles and the output Tile. Written to `LB0`. | No |
+| **validRow** | Number of valid rows in all source Tiles and the output Tile. Written to `LB1`. | Yes, defaults to 1 |
+| **Col** | Physical column count of the destination Tile, including padded columns. Written to `LB2`. | Yes, defaults to `validCol` |
+| **Row** | Physical row count of the destination Tile. Hardware derives this as `Size / (Col * sizeof(DataType))`. | Hardware-derived |
+| **DataType** | Element type in memory, also the element type of `SrcTile1` (expected) and `SrcTile2` (desired). | No |
+| **PadValue** | Fill value for destination elements outside the valid region. Supported values are `Null`, `Zero`, `Max`, and `Min`. | Yes, defaults to `Null` |
+| **RegSrc** | Base address register. | No |
+| **SrcTile0** | Offset Tile. Each element is a byte offset from `RegSrc`. | No |
+| **SrcTile1** | Expected value Tile (compare operand). Element type must match `DataType`. | No |
+| **SrcTile2** | Desired value Tile (swap operand). Element type must match `DataType`. | No |
+| **DstTile** | Output Tile that receives the old (pre-CAS) memory value at each position. | No |
+| **Size** | Destination Tile size in bytes. Must equal `Row * Col * sizeof(DataType)`. | No |
+
+The offset width is resolved from the element width used when `SrcTile0` was
+written. Canonical forms allow `u16`, `u32`, or `u64` offsets.
+
+## Encoding
+
+`MGATHER.CAS` expands to:
+
+- [BSTART.TMA](../../blockIntro/tma_block/header.md) `MGATHER.CAS, DataType`
+- [B.DATR](../../header/B.DATR.md) `PadValue` (optional)
+- [B.DIM](../../header/B.DIM.md) `reg, imm, ->LB0` (`validCol`)
+- [B.DIM](../../header/B.DIM.md) `reg, imm, ->LB1` (`validRow`)
+- [B.DIM](../../header/B.DIM.md) `reg, imm, ->LB2` (`Col`, optional)
+- [B.IOT](../../header/B.IOT.md) `SrcTile0<.reuse>, SrcTile1<.reuse>`
+- [B.IOT](../../header/B.IOT.md) `SrcTile2<.reuse>, last, ->DstTile<Size>`
+- [B.IOR](../../header/B.IOR.md) `RegSrc`
+
+## Execution model
+
+```c
+void MGATHER.CAS(Tile dst, Scalar base, Tile offset, Tile expected, Tile desired) {
+    for (int i = 0; i < Row; ++i) {
+        for (int j = 0; j < Col; ++j) {
+            if (i < validRow && j < validCol) {
+                offset_t off = offset[i][j];
+                // Atomic compare-and-swap on memory[base + off]
+                T old = MemoryAtomicCAS(base + off, expected[i][j], desired[i][j]);
+                dst[i][j] = old;
+            } else {
+                dst[i][j] = PadValue;
+            }
+        }
+    }
+}
+```
+
+## Notes
+
+- `validCol <= Col` and `validRow <= Row` must hold.
+- `Size` must be a whole multiple of `Col * sizeof(DataType)`.
+- Elements outside the valid region do not issue memory accesses.
+- The compare-and-swap is **atomic per element**: concurrent writes from other
+  agents to the same address are ordered by the hardware atomic unit.
+- A failed CAS (memory value does not match `expected`) writes the current
+  memory value to `DstTile` so the caller can decide whether to retry.
+- `SrcTile1` (expected) and `SrcTile2` (desired) must have the same element
+  type as `DataType`. Their tile shapes must match the offset Tile's valid
+  shape `[validRow, validCol]`.

--- a/docs/zh/isa/blockIntro/tma_block/header.md
+++ b/docs/zh/isa/blockIntro/tma_block/header.md
@@ -60,7 +60,8 @@ TileOp <LB0:arg0, LB1:arg1, LB2:arg2, DataType>, SrcTile0<.reuse>, ..., SrcTile7
 | 5 | [MSCATTER](../../header/tileblock/MSCATTER.md) | 将Tile寄存器中的数据存储到离散的内存空间。  |
 | 6 | [MGATHER.MASK](../../header/tileblock/MGATHER.MASK.md) | 带掩码的内存聚集，仅当 MaskTile 中对应标志位为 1 时才执行聚集。 |
 | 7 | [MSCATTER.MASK](../../header/tileblock/MSCATTER.MASK.md) | 带掩码的内存分散，仅当 MaskTile 中对应标志位为 1 时才执行分散。 |
-| 8-31 | 暂时保留 |
+| 8 | [MGATHER.CAS](../../header/tileblock/MGATHER.CAS.md) | 原子比较-交换内存聚集。逐元素原子 CAS 从内存聚集到 Tile。 |
+| 9-31 | 暂时保留 |
 
 DataType字段编码方式如下：
 

--- a/docs/zh/isa/header/tileblock/MGATHER.CAS.md
+++ b/docs/zh/isa/header/tileblock/MGATHER.CAS.md
@@ -1,0 +1,87 @@
+# MGATHER.CAS
+
+## 说明
+
+**原子比较-交换内存聚集（Atomic Compare-and-Swap Gather from Memory to Tile）**
+
+`MGATHER.CAS` 在 `MGATHER` 的基础上扩展了逐元素的原子比较-交换（CAS）操作。
+对每个有效元素，指令原子地比较目标内存地址的值与 `SrcTile1` 中存放的期望值
+（expected）；如果相等，则将 `SrcTile2` 中的新值（desired）写入同一内存地址。
+无论比较是否成功，**内存中的旧值**始终被写入输出 Tile（`DstTile`）。
+
+只有 `[0, validRow) × [0, validCol)` 的有效区域参与 CAS 操作；超出有效区域的
+输出位置写入 `PadValue`。
+
+比较值和交换值的元素类型必须与 `DataType` 一致。偏移量 Tile 的元素类型独立，
+可为 `u16`、`u32` 或 `u64`。
+
+## 汇编语法
+
+```asm
+MGATHER.CAS <LB0:validCol, LB1:validRow, LB2:Col, DataType, PadValue>,
+           SrcTile0<.reuse>, SrcTile1<.reuse>, SrcTile2<.reuse>,
+           [RegSrc], ->DstTile<Size>
+```
+
+## 汇编符号
+
+| 参数 | 说明 | 是否可选 |
+|------|------|---------|
+| **validCol** | 三个源 Tile 和输出 Tile 的有效列数。通过 `LB0` 传入。 | 否 |
+| **validRow** | 三个源 Tile 和输出 Tile 的有效行数。通过 `LB1` 传入。 | 是，默认为 1 |
+| **Col** | 输出 Tile 每行的物理列数（包含填充列）。通过 `LB2` 传入。 | 是，默认等于 `validCol` |
+| **Row** | 输出 Tile 的物理行数（包含填充行）。硬件通过 `Size / (Col * sizeof(DataType))` 自动推导。 | 否（硬件推导） |
+| **DataType** | 内存中元素的类型，也是 `SrcTile1`（期望值）和 `SrcTile2`（新值）的元素类型。 | 否 |
+| **PadValue** | DstTile 中位于有效区域之外的填充值。可选值为 `Null`、`Zero`、`Max`、`Min`。 | 是，默认 `Null` |
+| **RegSrc** | 输入全局寄存器 GGPR，用于存放 CAS 操作的内存基地址 `baseAddress`。 | 否 |
+| **SrcTile0** | 偏移量 Tile，每个元素是一个相对于 `baseAddress` 的字节偏移量。 | 否 |
+| **SrcTile1** | 期望值 Tile（比较操作数），元素类型必须与 `DataType` 一致。 | 否 |
+| **SrcTile2** | 新值 Tile（交换操作数），元素类型必须与 `DataType` 一致。 | 否 |
+| **DstTile** | 输出 Tile，用于存放 CAS 操作前内存中的旧值。 | 否 |
+| **Size** | 输出 Tile 的大小，必须等于 `Row * Col * sizeof(DataType)`。 | 否 |
+
+`SrcTile0` 中 offset 的位宽由写入该 Tile 时使用的元素位宽决定，规范形式
+支持 `u16`、`u32` 和 `u64`。
+
+## 编码格式
+
+`MGATHER.CAS` 编码为以下指令：
+
+- [BSTART.TMA](../../blockIntro/tma_block/header.md) `MGATHER.CAS, DataType`
+- [B.DATR](../../header/B.DATR.md) `PadValue` *（可选）*
+- [B.DIM](../../header/B.DIM.md) `reg, imm, ->LB0` *（`validCol`）*
+- [B.DIM](../../header/B.DIM.md) `reg, imm, ->LB1` *（`validRow`）*
+- [B.DIM](../../header/B.DIM.md) `reg, imm, ->LB2` *（`Col`，可选）*
+- [B.IOT](../../header/B.IOT.md) `SrcTile0<.reuse>, SrcTile1<.reuse>`
+- [B.IOT](../../header/B.IOT.md) `SrcTile2<.reuse>, last, ->DstTile<Size>`
+- [B.IOR](../../header/B.IOR.md) `RegSrc`
+
+## 执行模型
+
+```c
+void MGATHER.CAS(Tile dst, Scalar base, Tile offset, Tile expected, Tile desired) {
+    for (int i = 0; i < Row; ++i) {
+        for (int j = 0; j < Col; ++j) {
+            if (i < validRow && j < validCol) {
+                offset_t off = offset[i][j];
+                // 对 memory[base + off] 执行原子 CAS
+                T old = MemoryAtomicCAS(base + off, expected[i][j], desired[i][j]);
+                dst[i][j] = old;
+            } else {
+                dst[i][j] = PadValue;
+            }
+        }
+    }
+}
+```
+
+## 注意事项
+
+- `validCol <= Col`, `validRow <= Row`。
+- `Size` 必须是 `Col * sizeof(DataType)` 的整数倍。
+- 超出有效区域的位置不产生访存，直接写入 `PadValue`。
+- **比较-交换是逐元素原子的**：来自其他代理对同一地址的并发写入由硬件原子单元排序。
+- CAS 失败时（内存值不匹配期望值），仍将当前内存值写入 `DstTile`，调用方
+  可据此决定是否需要重试。
+- `SrcTile1`（期望值）和 `SrcTile2`（新值）的元素类型必须与 `DataType` 一致。
+  两者的有效形状必须与偏移量 Tile 对齐，即 `[validRow, validCol]`。


### PR DESCRIPTION
## Summary
- Introduce `MGATHER.CAS`, a new tileblock memory instruction that performs per-element atomic compare-and-swap from sparse memory (`base + offset Tile`) into a destination Tile, returning the pre-CAS memory value on every lane so callers can detect failure and retry.
- Register TileOp slot 8 in `tma_block/header.md` and ship EN/ZH instruction docs covering assembly syntax, parameter table, BSTART.TMA / B.DIM / B.IOT / B.IOR encoding expansion, and C execution model.
- Naming follows the existing `MGATHER.MASK` / `MSCATTER.MASK` dot-suffix convention, keeping the load shape (GATHER) and per-element op (CAS) visually separated and leaving room for future atomic RMW siblings (XCHG / ADD / MIN / MAX).

## Test plan
- [ ] Reviewer confirms TileOp slot 8 is free and the encoding expansion matches hardware behavior.
- [ ] Reviewer confirms the C pseudo-code semantics — especially the failed-CAS old-value write and `PadValue` fill outside the valid region — match the intended atomic semantics.
- [ ] Reviewer confirms links from `tma_block/header.md` (EN + ZH) to the new `MGATHER.CAS.md` resolve in the rendered docs site.