### PR TITLE
test(avs): add v0.58 tile engine runtime coverage

### DIFF
--- a/avs/README.md
+++ b/avs/README.md
@@ -1,6 +1,7 @@
 # Architecture Validation Suite (AVS)
 
-This directory contains the canonical **Architecture Validation Suite** for LinxISA v0.57.
+This directory contains the canonical **Architecture Validation Suite** for
+LinxISA v0.58.
 
 ## Overview
 
@@ -21,9 +22,19 @@ The AVS validates that all implementations (compiler, emulator, RTL, kernel) con
 ### Runtime Tests (QEMU)
 
 ```bash
-cd avs/qemu
-./run_tests.sh --all --timeout 10
+python3 avs/qemu/run_tests.py \
+  --suite tile_v058_tlsu \
+  --suite tile_v058_vec \
+  --suite tile_v058_sfu \
+  --suite tile_v058_cube \
+  --timeout 30 \
+  --no-progress-timeout 15
 ```
+
+The v0.58 Tile runtime lane covers all four architectural execution engines:
+TLSU, VEC, SFU, and CUBE. Each suite combines a canonical assembly carrier
+with an independent freestanding C oracle. A QEMU exit code or agreement with
+another model is not sufficient on its own.
 
 ### Compile Tests (LLVM)
 

--- a/avs/linx_avs_v1_test_matrix.yaml
+++ b/avs/linx_avs_v1_test_matrix.yaml
@@ -1,6 +1,6 @@
-version: linx-avs-v0.57
+version: linx-avs-v0.58
 status: canonical
-last_updated: "2026-03-07"
+last_updated: "2026-08-13"
 
 profiles:
   LNX-S32: "Scalar 32-bit, freestanding, little-endian, no MMU"
@@ -10,7 +10,7 @@ profiles:
   LNX-FP: "Adds scalar and vector floating-point behavior"
   LNX-VPAR: "Enables vector parallel blocks"
   LNX-VSEQ: "Enables vector sequential blocks"
-  LNX-TILE: "Enables tile blocks and TAU execution"
+  LNX-TILE: "Enables PTO v0.58 TLSU, VEC, SFU, and CUBE Tile execution"
   LNX-LINUX: "Linux runtime and privileged execution under QEMU"
   LNX-LIBC: "musl/glibc runtime and loader behavior"
   LNX-WORKLOAD: "Benchmarks and maintained workload runners on QEMU"
@@ -33,7 +33,7 @@ tests:
     profiles: [LNX-S32, LNX-S64]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - docs/archive/v0.57/architecture/v0.57-architecture-contract.md
+      - docs/architecture/v0.58-architecture-contract.md
       - docs/architecture/isa-manual/src/chapters/04_block_isa.adoc
     requirement: "Any encoding not matched by the canonical ISA catalog traps as illegal instruction."
     pass_fail: "QEMU and reference decode vectors trap on the same byte sequence with no partial side effects."
@@ -46,7 +46,7 @@ tests:
     must_pass_in_tier: [nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/04_block_isa.adoc
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
     requirement: "All-zero 16-bit encoding (0x0000) is handled intentionally as C.BSTOP or defined illegal, consistently."
     pass_fail: "Executing 0x0000 at a valid TPC produces the architecturally defined behavior."
 
@@ -57,9 +57,9 @@ tests:
     profiles: [LNX-S32, LNX-S64, LNX-PRIV, LNX-ATOM, LNX-FP, LNX-VPAR, LNX-VSEQ, LNX-TILE]
     must_pass_in_tier: [pr, nightly]
     spec_refs:
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
       - docs/architecture/isa-manual/src/generated/instruction_reference.adoc
-    requirement: "llvm-objdump recognizes and prints a mnemonic token for every current v0.57 spec mnemonic."
+    requirement: "llvm-objdump recognizes and prints a mnemonic token for every current v0.58 spec mnemonic."
     pass_fail: "python3 avs/compiler/linx-llvm/tests/analyze_coverage.py --fail-under 100 exits 0."
 
   - id: AVS-TOOL-010
@@ -69,9 +69,9 @@ tests:
     profiles: [LNX-S32, LNX-S64]
     must_pass_in_tier: [pr, nightly]
     spec_refs:
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
       - docs/architecture/isa-manual/src/chapters/06_assembly_conventions.adoc
-    requirement: "llvm-mc asm/disasm round-trip for canonical instruction forms matches the v0.57 catalog."
+    requirement: "llvm-mc asm/disasm round-trip for canonical instruction forms matches the v0.58 catalog."
     pass_fail: "Assemble, disassemble, and remap mnemonic back to the same canonical spec entry for the generated vector set."
 
   - id: AVS-TOOL-011
@@ -81,7 +81,7 @@ tests:
     profiles: [LNX-S32, LNX-S64]
     must_pass_in_tier: [pr, nightly]
     spec_refs:
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
       - docs/reference/encoding_space_report.md
     requirement: "Generated spec decode vectors disassemble with 100% canonical mnemonic coverage."
     pass_fail: "99_spec_decode objdump coverage remains 100% for the active registered baremetal compiler profiles."
@@ -93,14 +93,14 @@ tests:
     profiles: [LNX-S32, LNX-S64, LNX-PRIV, LNX-ATOM, LNX-FP, LNX-VPAR, LNX-VSEQ, LNX-TILE]
     must_pass_in_tier: [pr, nightly]
     spec_refs:
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
       - docs/architecture/isa-manual/src/chapters/04_block_isa.adoc
       - docs/architecture/isa-manual/src/chapters/06_assembly_conventions.adoc
       - docs/architecture/isa-manual/src/chapters/08_tile_blocks.adoc
       - docs/architecture/isa-manual/src/chapters/10_system_and_privilege.adoc
       - docs/architecture/isa-manual/src/chapters/13_fsu.adoc
       - docs/architecture/isa-manual/src/chapters/14_amo.adoc
-    requirement: "Curated positive assembly vectors cover v0.57 block, tile, vector, system, FSU, and AMO mnemonic families that C lowering may not emit."
+    requirement: "Curated positive assembly vectors cover v0.58 block, tile, vector, system, FSU, and AMO mnemonic families that C lowering may not emit."
     pass_fail: "run.sh assembles asm/41_v057_isa_forms.s with llvm-mc, disassembles it with llvm-objdump, and check_required_mnemonics.py confirms the required mnemonic set."
 
   - id: AVS-BLK-001
@@ -110,7 +110,7 @@ tests:
     profiles: [LNX-S32, LNX-S64]
     must_pass_in_tier: [pr, nightly]
     spec_refs:
-      - docs/archive/v0.57/architecture/v0.57-architecture-contract.md
+      - docs/architecture/v0.58-architecture-contract.md
       - docs/architecture/isa-manual/src/chapters/04_block_isa.adoc
     requirement: "Control-flow targets must land on block start markers."
     pass_fail: "Jumping into the middle of a block traps with correct BPC/TPC capture."
@@ -124,7 +124,7 @@ tests:
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/04_block_isa.adoc
       - docs/architecture/isa-manual/src/chapters/03_programming_model.adoc
-    requirement: "Block boundary commit rules and implicit boundary transitions follow the v0.57 manual."
+    requirement: "Block boundary commit rules and implicit boundary transitions follow the v0.58 manual."
     pass_fail: "Directed programs show correct transitions with and without explicit BSTOP."
 
   - id: AVS-BLK-003
@@ -158,9 +158,9 @@ tests:
     must_pass_in_tier: [pr, nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/04_block_isa.adoc
-      - docs/archive/v0.57/architecture/v0.57-architecture-contract.md
-    requirement: "Canonical vector block types are BSTART.VPAR and BSTART.VSEQ only."
-    pass_fail: "Repo and runtime suites contain no live BSTART.VEC behavior."
+      - docs/architecture/v0.58-architecture-contract.md
+    requirement: "SIMT vector body blocks use BSTART.VPAR or BSTART.VSEQ; Tile element-wise operations use the distinct BSTART.VEC engine alias carried by TEPL."
+    pass_fail: "Directed decode and runtime tests distinguish VPAR/VSEQ body execution from v0.58 Tile VEC header execution."
 
   - id: AVS-ALU-001
     state: active
@@ -170,7 +170,7 @@ tests:
     must_pass_in_tier: [pr, nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/12_alu.adoc
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
     requirement: "ADD/ADDI/SUB/SUBI correctness includes edge cases."
     pass_fail: "Directed tests cover 0, -1, INT_MIN/INT_MAX, and mixed-sign behavior."
 
@@ -182,7 +182,7 @@ tests:
     must_pass_in_tier: [pr, nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/12_alu.adoc
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
     requirement: "MUL/DIV/REM correctness includes signedness and divide-by-zero behavior."
     pass_fail: "Directed tests cover DIV/DIVU/REM/REMU and *W forms with defined outcomes."
 
@@ -241,7 +241,7 @@ tests:
     must_pass_in_tier: [pr, nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/09_memory_operations.adoc
-      - isa/v0.57/state/memory_model.json
+      - isa/v0.58/state/memory_model.json
     requirement: "Scaled versus unscaled immediate offsets compute exact addresses."
     pass_fail: "Directed tests validate addresses touched by scaled and .U families."
 
@@ -252,7 +252,7 @@ tests:
     profiles: [LNX-ATOM]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - isa/v0.57/state/memory_model.json
+      - isa/v0.58/state/memory_model.json
       - docs/architecture/isa-manual/src/chapters/14_amo.adoc
     requirement: "Atomic .aq/.rl qualifiers enforce acquire/release ordering as specified."
     pass_fail: "Litmus tests exclude forbidden outcomes when qualifiers are used."
@@ -264,7 +264,7 @@ tests:
     profiles: [LNX-ATOM]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - isa/v0.57/state/memory_model.json
+      - isa/v0.58/state/memory_model.json
       - docs/architecture/isa-manual/src/chapters/14_amo.adoc
     requirement: "FENCE.D pred,succ orders the specified operation classes."
     pass_fail: "Litmus tests and microbenchmarks confirm ordering and no-op cases."
@@ -276,7 +276,7 @@ tests:
     profiles: [LNX-ATOM]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - isa/v0.57/state/memory_model.json
+      - isa/v0.58/state/memory_model.json
       - docs/architecture/isa-manual/src/chapters/14_amo.adoc
     requirement: "FENCE.I synchronizes instruction fetch with prior executable stores."
     pass_fail: "Self-modifying-code test behaves as specified or traps only when the spec says it may."
@@ -288,7 +288,7 @@ tests:
     profiles: [LNX-ATOM]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - isa/v0.57/state/memory_model.json
+      - isa/v0.58/state/memory_model.json
       - docs/architecture/isa-manual/src/chapters/14_amo.adoc
     requirement: "Message passing requires acquire/release or fence to forbid the weak outcome."
     pass_fail: "Litmus harness observes allowed and forbidden outcome sets per requirement."
@@ -300,7 +300,7 @@ tests:
     profiles: [LNX-ATOM]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - isa/v0.57/state/memory_model.json
+      - isa/v0.58/state/memory_model.json
       - docs/architecture/isa-manual/src/chapters/14_amo.adoc
     requirement: "FENCE.D orders MMIO and Normal memory when O is selected."
     pass_fail: "Directed tests with the MMIO model observe ordering consistent with the fence definition."
@@ -313,7 +313,7 @@ tests:
     must_pass_in_tier: [pr, nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/10_system_and_privilege.adoc
-      - docs/archive/v0.57/architecture/v0.57-architecture-contract.md
+      - docs/architecture/v0.58-architecture-contract.md
     requirement: "ACRC is last in a block and routes or traps as specified."
     pass_fail: "Placement violations trigger the defined trap; valid requests route to the managing ring vector."
 
@@ -325,7 +325,7 @@ tests:
     must_pass_in_tier: [pr, nightly]
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/10_system_and_privilege.adoc
-      - isa/v0.57/state/kernel_execution.json
+      - isa/v0.58/state/kernel_execution.json
     requirement: "ACRE restores state per the manual."
     pass_fail: "Trap handler returns and execution resumes at the expected block start."
 
@@ -410,7 +410,7 @@ tests:
     spec_refs:
       - docs/architecture/isa-manual/src/chapters/13_fsu.adoc
       - isa/sail/semantics_status.json
-    requirement: "Scalar FP ops match the v0.57 numeric and FCSR rules."
+    requirement: "Scalar FP ops match the v0.58 numeric and FCSR rules."
     pass_fail: "Directed tests cover NaNs, signed zero, infinities, and flag setting or clearing."
 
   - id: AVS-FP-002
@@ -432,7 +432,7 @@ tests:
     profiles: [LNX-VPAR, LNX-VSEQ]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - docs/archive/v0.57/architecture/v0.57-architecture-contract.md
+      - docs/architecture/v0.58-architecture-contract.md
       - docs/architecture/isa-manual/src/chapters/20_vec.adoc
     requirement: "Vector ops that require vector blocks trap when executed outside vector blocks."
     pass_fail: "Vector op outside the correct header traps; inside the header it executes and updates state."
@@ -461,6 +461,66 @@ tests:
     requirement: "Compressed vector block start markers begin new vector blocks."
     pass_fail: "Directed programs use compressed markers and subsequent vector ops execute."
 
+  - id: AVS-TILE-TLSU-001
+    state: active
+    area: TILE
+    domain: Emulator
+    profiles: [LNX-TILE]
+    must_pass_in_tier: [pr, nightly]
+    spec_refs:
+      - isa/v0.58/linxisa-v0.58.json
+      - docs/architecture/v0.58-architecture-contract.md
+      - docs/architecture/isa-manual/src/chapters/09_memory_operations.adoc
+      - avs/qemu/tests/28_v058_tile_tlsu.c
+      - avs/qemu/tests/28_v058_tile_tlsu_carrier.S
+    requirement: "The v0.58 TLSU TLOAD/TSTORE path transfers a nontrivial FP32 payload using Function 0/1 headers, canonical B.IOR base/stride roles, and a 4 KiB Local tile."
+    pass_fail: "run_tests.py --suite tile_v058_tlsu observes test 0x2A01 PASS after the C oracle compares all 1024 output words with the input payload."
+
+  - id: AVS-TILE-VEC-001
+    state: active
+    area: TILE
+    domain: Emulator
+    profiles: [LNX-TILE]
+    must_pass_in_tier: [pr, nightly]
+    spec_refs:
+      - isa/v0.58/linxisa-v0.58.json
+      - docs/architecture/v0.58-architecture-contract.md
+      - docs/architecture/isa-manual/src/chapters/08_tile_blocks.adoc
+      - avs/qemu/tests/29_v058_tile_vec.c
+      - avs/qemu/tests/29_v058_tile_vec_carrier.S
+    requirement: "The v0.58 VEC engine executes FP32 TADD through the unchanged TEPL encoding carrier and publishes the destination Tile payload."
+    pass_fail: "run_tests.py --suite tile_v058_vec observes test 0x2B01 PASS after the C oracle verifies every output element is the FP32 bit pattern for 3.0."
+
+  - id: AVS-TILE-SFU-001
+    state: active
+    area: TILE
+    domain: Emulator
+    profiles: [LNX-TILE]
+    must_pass_in_tier: [pr, nightly]
+    spec_refs:
+      - isa/v0.58/linxisa-v0.58.json
+      - docs/architecture/v0.58-architecture-contract.md
+      - docs/architecture/isa-manual/src/chapters/08_tile_blocks.adoc
+      - avs/qemu/tests/30_v058_tile_sfu.c
+      - avs/qemu/tests/30_v058_tile_sfu_carrier.S
+    requirement: "The v0.58 SFU engine executes FP32 TEXP through the unchanged TEPL encoding carrier and publishes the destination Tile payload."
+    pass_fail: "run_tests.py --suite tile_v058_sfu observes test 0x2C01 PASS after the C oracle verifies every exp(0.0) result is the FP32 bit pattern for 1.0."
+
+  - id: AVS-TILE-CUBE-001
+    state: active
+    area: TILE
+    domain: Emulator
+    profiles: [LNX-TILE]
+    must_pass_in_tier: [pr, nightly]
+    spec_refs:
+      - isa/v0.58/linxisa-v0.58.json
+      - docs/architecture/v0.58-architecture-contract.md
+      - docs/architecture/isa-manual/src/chapters/08_tile_blocks.adoc
+      - avs/qemu/tests/31_v058_tile_cube.c
+      - avs/qemu/tests/31_v058_tile_cube_carrier.S
+    requirement: "The v0.58 CUBE engine decodes TMATMUL dimensions as M, N, K and executes an S32 4x4 matrix product."
+    pass_fail: "run_tests.py --suite tile_v058_cube observes test 0x2D01 PASS after the C oracle verifies identity-times-right equals the right matrix."
+
   - id: AVS-EMU-001
     state: active
     area: EMU
@@ -468,7 +528,7 @@ tests:
     profiles: [LNX-S32, LNX-S64]
     must_pass_in_tier: [pr, nightly]
     spec_refs:
-      - docs/archive/v0.57/architecture/v0.57-architecture-contract.md
+      - docs/architecture/v0.58-architecture-contract.md
       - docs/architecture/isa-manual/src/chapters/10_system_and_privilege.adoc
     requirement: "Illegal encodings trap deterministically with no partial state committed."
     pass_fail: "Negative tests validate trap PC and cause plus unchanged regs and memory."
@@ -480,9 +540,9 @@ tests:
     profiles: [LNX-S32, LNX-S64, LNX-PRIV, LNX-ATOM, LNX-FP, LNX-VPAR, LNX-VSEQ, LNX-TILE]
     must_pass_in_tier: [nightly]
     spec_refs:
-      - isa/v0.57/linxisa-v0.57.json
+      - isa/v0.58/linxisa-v0.58.json
       - docs/bringup/ALIGNMENT_MATRIX.md
-    requirement: "Every current v0.57 instruction should have explicit AVS QEMU translation-test coverage tracked from per-source unit-test objects."
+    requirement: "Every current v0.58 instruction should have explicit AVS QEMU translation-test coverage tracked from per-source unit-test objects."
     pass_fail: "report_qemu_translation_coverage.py emits machine-readable mnemonic/object coverage and exits 0 under --require-full only when coverage reaches 100%."
 
   - id: AVS-EMU-010

--- a/avs/linx_avs_v1_test_matrix_status.json
+++ b/avs/linx_avs_v1_test_matrix_status.json
@@ -41,9 +41,9 @@
       "tests": 2
     },
     "LNX-TILE": {
-      "implemented": 3,
-      "pass": 3,
-      "tests": 4
+      "implemented": 7,
+      "pass": 7,
+      "tests": 8
     },
     "LNX-VPAR": {
       "implemented": 3,
@@ -191,65 +191,129 @@
       "source": "ev-0032"
     },
     "ev-0033": {
-      "kind": "note",
-      "source": "ev-0033"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/28_v058_tile_tlsu.c",
+      "source": "avs/qemu/tests/28_v058_tile_tlsu.c"
     },
     "ev-0034": {
-      "kind": "note",
-      "source": "ev-0034"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/28_v058_tile_tlsu_carrier.S",
+      "source": "avs/qemu/tests/28_v058_tile_tlsu_carrier.S"
     },
     "ev-0035": {
       "kind": "note",
-      "source": "ev-0035"
+      "source": "python3 avs/qemu/run_tests.py --suite tile_v058_tlsu --require-test-id 0x2A01"
     },
     "ev-0036": {
-      "kind": "note",
-      "source": "ev-0036"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/29_v058_tile_vec.c",
+      "source": "avs/qemu/tests/29_v058_tile_vec.c"
     },
     "ev-0037": {
-      "kind": "note",
-      "source": "ev-0037"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/29_v058_tile_vec_carrier.S",
+      "source": "avs/qemu/tests/29_v058_tile_vec_carrier.S"
     },
     "ev-0038": {
       "kind": "note",
-      "source": "ev-0038"
+      "source": "python3 avs/qemu/run_tests.py --suite tile_v058_vec --require-test-id 0x2B01"
     },
     "ev-0039": {
-      "kind": "note",
-      "source": "ev-0039"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/30_v058_tile_sfu.c",
+      "source": "avs/qemu/tests/30_v058_tile_sfu.c"
     },
     "ev-0040": {
-      "kind": "note",
-      "source": "ev-0040"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/30_v058_tile_sfu_carrier.S",
+      "source": "avs/qemu/tests/30_v058_tile_sfu_carrier.S"
     },
     "ev-0041": {
       "kind": "note",
-      "source": "ev-0041"
+      "source": "python3 avs/qemu/run_tests.py --suite tile_v058_sfu --require-test-id 0x2C01"
     },
     "ev-0042": {
-      "kind": "note",
-      "source": "ev-0042"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/31_v058_tile_cube.c",
+      "source": "avs/qemu/tests/31_v058_tile_cube.c"
     },
     "ev-0043": {
-      "kind": "note",
-      "source": "ev-0043"
+      "exists": true,
+      "kind": "path",
+      "path": "avs/qemu/tests/31_v058_tile_cube_carrier.S",
+      "source": "avs/qemu/tests/31_v058_tile_cube_carrier.S"
     },
     "ev-0044": {
       "kind": "note",
-      "source": "ev-0044"
+      "source": "python3 avs/qemu/run_tests.py --suite tile_v058_cube --require-test-id 0x2D01"
     },
     "ev-0045": {
       "kind": "note",
-      "source": "ev-0045"
+      "source": "ev-0033"
     },
     "ev-0046": {
+      "kind": "note",
+      "source": "ev-0034"
+    },
+    "ev-0047": {
+      "kind": "note",
+      "source": "ev-0035"
+    },
+    "ev-0048": {
+      "kind": "note",
+      "source": "ev-0036"
+    },
+    "ev-0049": {
+      "kind": "note",
+      "source": "ev-0037"
+    },
+    "ev-0050": {
+      "kind": "note",
+      "source": "ev-0038"
+    },
+    "ev-0051": {
+      "kind": "note",
+      "source": "ev-0039"
+    },
+    "ev-0052": {
+      "kind": "note",
+      "source": "ev-0040"
+    },
+    "ev-0053": {
+      "kind": "note",
+      "source": "ev-0041"
+    },
+    "ev-0054": {
+      "kind": "note",
+      "source": "ev-0042"
+    },
+    "ev-0055": {
+      "kind": "note",
+      "source": "ev-0043"
+    },
+    "ev-0056": {
+      "kind": "note",
+      "source": "ev-0044"
+    },
+    "ev-0057": {
+      "kind": "note",
+      "source": "ev-0045"
+    },
+    "ev-0058": {
       "kind": "note",
       "source": "ev-0046"
     }
   },
-  "generated_at_utc": "2026-08-10 05:55:07Z",
+  "generated_at_utc": "2026-08-12 16:33:58Z",
   "matrix_file": "avs/linx_avs_v1_test_matrix.yaml",
-  "schema_version": "linx-avs-v0.57-status-v1",
+  "schema_version": "linx-avs-v0.58-status-v1",
   "statuses": {
     "AVS-ABI-001": {
       "evidence": [
@@ -396,7 +460,7 @@
     },
     "AVS-EMU-001": {
       "evidence": [
-        "ev-0033"
+        "ev-0045"
       ],
       "implemented": true,
       "validated": "pass"
@@ -423,49 +487,49 @@
     },
     "AVS-LIBC-001": {
       "evidence": [
-        "ev-0039"
+        "ev-0051"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-LIBC-002": {
       "evidence": [
-        "ev-0040"
+        "ev-0052"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-LIBC-003": {
       "evidence": [
-        "ev-0041"
+        "ev-0053"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-LIBC-004": {
       "evidence": [
-        "ev-0042"
+        "ev-0054"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-LINUX-001": {
       "evidence": [
-        "ev-0036"
+        "ev-0048"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-LINUX-002": {
       "evidence": [
-        "ev-0037"
+        "ev-0049"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-LINUX-003": {
       "evidence": [
-        "ev-0038"
+        "ev-0050"
       ],
       "implemented": true,
       "validated": "pass"
@@ -495,14 +559,14 @@
     },
     "AVS-MODEL-001": {
       "evidence": [
-        "ev-0034"
+        "ev-0046"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-MODEL-002": {
       "evidence": [
-        "ev-0035"
+        "ev-0047"
       ],
       "implemented": true,
       "validated": "pass"
@@ -522,6 +586,42 @@
     "AVS-SYS-002": {
       "evidence": [
         "ev-0021"
+      ],
+      "implemented": true,
+      "validated": "pass"
+    },
+    "AVS-TILE-CUBE-001": {
+      "evidence": [
+        "ev-0042",
+        "ev-0043",
+        "ev-0044"
+      ],
+      "implemented": true,
+      "validated": "pass"
+    },
+    "AVS-TILE-SFU-001": {
+      "evidence": [
+        "ev-0039",
+        "ev-0040",
+        "ev-0041"
+      ],
+      "implemented": true,
+      "validated": "pass"
+    },
+    "AVS-TILE-TLSU-001": {
+      "evidence": [
+        "ev-0033",
+        "ev-0034",
+        "ev-0035"
+      ],
+      "implemented": true,
+      "validated": "pass"
+    },
+    "AVS-TILE-VEC-001": {
+      "evidence": [
+        "ev-0036",
+        "ev-0037",
+        "ev-0038"
       ],
       "implemented": true,
       "validated": "pass"
@@ -574,21 +674,21 @@
     },
     "AVS-WORK-001": {
       "evidence": [
-        "ev-0043"
+        "ev-0055"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-WORK-002": {
       "evidence": [
-        "ev-0044"
+        "ev-0056"
       ],
       "implemented": true,
       "validated": "pass"
     },
     "AVS-WORK-003": {
       "evidence": [
-        "ev-0045"
+        "ev-0057"
       ],
       "implemented": true,
       "validated": "pass"
@@ -600,7 +700,7 @@
     },
     "AVS-WORK-005": {
       "evidence": [
-        "ev-0046"
+        "ev-0058"
       ],
       "implemented": true,
       "validated": "pass"
@@ -613,14 +713,14 @@
   },
   "tier_summaries": {
     "nightly": {
-      "implemented": 32,
-      "pass": 32,
-      "tests": 54
+      "implemented": 36,
+      "pass": 36,
+      "tests": 58
     },
     "pr": {
-      "implemented": 31,
-      "pass": 31,
-      "tests": 31
+      "implemented": 35,
+      "pass": 35,
+      "tests": 35
     }
   }
 }

--- a/avs/matrix_v1.md
+++ b/avs/matrix_v1.md
@@ -1,6 +1,7 @@
-# Linx-AVS v1 Test Matrix
+# Linx-AVS v0.58 Test Matrix
 
-Version: v1 (draft)
+Version: v0.58 (canonical machine-readable source:
+`avs/linx_avs_v1_test_matrix.yaml`)
 
 This file is a **test matrix**, not an implementation. It defines test IDs,
 required architectural behavior, and pass/fail criteria. A later agent should
@@ -20,7 +21,7 @@ useful subset without pretending vector/tile/MMU are done.
 - `LNX-FP`: adds scalar FP + FCSR behavior
 - `LNX-VPAR`: enables vector blocks (`BSTART.VPAR`)
 - `LNX-VSEQ`: enables vector blocks (`BSTART.VSEQ`)
-- `LNX-TILE`: enables tile blocks / TAU (not required for v1 pass)
+- `LNX-TILE`: enables PTO v0.58 TLSU, VEC, SFU, and CUBE Tile execution
 
 Unless stated otherwise, tests apply to both `LNX-S32` and `LNX-S64`.
 

--- a/avs/qemu/README.md
+++ b/avs/qemu/README.md
@@ -63,6 +63,8 @@ Active runtime note:
 
 - the live QEMU runtime lane keeps the `system`, `callret`, scalar, and the
   still-supported handwritten `v057` SIMT/vector suites;
+- the LinxISA/PTO v0.58 Tile lane is split by execution engine into
+  `tile_v058_tlsu`, `tile_v058_vec`, `tile_v058_sfu`, and `tile_v058_cube`;
 - the older handwritten `v04_vector_ops` runtime suite is removed from the
   active surface on this Bisheng branch because the current compiler/MC stack
   does not accept that handwritten asm dialect reliably enough for gating.
@@ -76,6 +78,47 @@ Run a specific suite:
 ./run_tests.sh --suite jumptable
 ./run_tests.sh --suite varargs
 ```
+
+Run the complete v0.58 Tile engine smoke with bounded execution:
+
+```bash
+python3 avs/qemu/run_tests.py \
+  --suite tile_v058_tlsu \
+  --suite tile_v058_vec \
+  --suite tile_v058_sfu \
+  --suite tile_v058_cube \
+  --timeout 30 \
+  --no-progress-timeout 15 \
+  --heartbeat-sec 2
+```
+
+The Tile cases compile `*_carrier.S` with canonical v0.58 mnemonics and use
+the corresponding C source as an independent result oracle:
+
+| Suite | Architectural check |
+|-------|---------------------|
+| `tile_v058_tlsu` | FP32 TLOAD/TSTORE transfers a nontrivial 4 KiB payload |
+| `tile_v058_vec` | FP32 TADD produces `1.0 + 2.0 = 3.0` |
+| `tile_v058_sfu` | FP32 TEXP produces `exp(0.0) = 1.0` |
+| `tile_v058_cube` | S32 4x4 identity TMATMUL reproduces the right operand |
+
+Every output buffer starts with a non-golden sentinel. This prevents a
+non-writing implementation from passing. The runner also checks the carrier
+object's disassembly before linking and records START/PASS IDs in structured
+runtime evidence when `--evidence-out` is supplied.
+
+Current v0.58 frontend boundary:
+
+- the pinned TileOP C++ API still depends on removed LinxV5 extensions such as
+  `__fp32`, `tile_size(...)`, and the `Tr` inline-assembly constraint;
+- current LLVM Tile intrinsic lowering reverses the two v0.58 `B.IOR` source
+  roles (`RegSrc0=base`, `RegSrc1=row stride`).
+
+The engine smoke therefore uses canonical assembly carriers instead of
+claiming that the obsolete C++ Tile frontend is valid runtime evidence. The
+assembly parser must encode bare `BSTART.TSTORE DataType` as the base Local
+TSTORE form (TLSU Function 1), not the textually identical Shared partition
+variant (Function 14).
 
 Run everything (includes float + atomic):
 
@@ -126,10 +169,10 @@ rm -rf out
 ./run_tests.sh --all --compile-only
 ```
 
-Custom output directory:
+Custom repository-local output directory:
 
 ```bash
-./run_tests.sh --out-dir /tmp/linx-qemu-tests --all --compile-only
+./run_tests.sh --out-dir .codex_logs/avs-qemu --all --compile-only
 ```
 
 ## Outputs

--- a/avs/qemu/run_tests.py
+++ b/avs/qemu/run_tests.py
@@ -75,6 +75,10 @@ COMPLETION_TEST_IDS_BY_SUITE = {
     "executable_hl_cmp": 0x00002707,
     "executable_setc_imm": 0x0000280A,
     "executable_maddw_bfi_mi": 0x00002904,
+    "tile_v058_tlsu": 0x00002A01,
+    "tile_v058_vec": 0x00002B01,
+    "tile_v058_sfu": 0x00002C01,
+    "tile_v058_cube": 0x00002D01,
     "system": 0x0000110D,
 }
 
@@ -536,11 +540,36 @@ SUITES: dict[str, dict[str, str]] = {
         "src": "tests/27_executable_maddw_bfi_mi.c",
         "macro": "LINX_TEST_ENABLE_MADDW_BFI_MI",
     },
+    "tile_v058_tlsu": {
+        "src": "tests/28_v058_tile_tlsu.c",
+        "macro": "LINX_TEST_ENABLE_TILE_V058_TLSU",
+    },
+    "tile_v058_vec": {
+        "src": "tests/29_v058_tile_vec.c",
+        "macro": "LINX_TEST_ENABLE_TILE_V058_VEC",
+    },
+    "tile_v058_sfu": {
+        "src": "tests/30_v058_tile_sfu.c",
+        "macro": "LINX_TEST_ENABLE_TILE_V058_SFU",
+    },
+    "tile_v058_cube": {
+        "src": "tests/31_v058_tile_cube.c",
+        "macro": "LINX_TEST_ENABLE_TILE_V058_CUBE",
+    },
 }
 
 COMPILE_ONLY_SUITE_SOURCE_OVERRIDE: dict[str, str] = {}
 
+EXTRA_SOURCES_BY_SUITE: dict[str, list[str]] = {
+    "tile_v058_tlsu": ["avs/qemu/tests/28_v058_tile_tlsu_carrier.S"],
+    "tile_v058_vec": ["avs/qemu/tests/29_v058_tile_vec_carrier.S"],
+    "tile_v058_sfu": ["avs/qemu/tests/30_v058_tile_sfu_carrier.S"],
+    "tile_v058_cube": ["avs/qemu/tests/31_v058_tile_cube_carrier.S"],
+}
+
 def _extra_sources_for_suite(suite: str) -> list[str]:
+    if suite in EXTRA_SOURCES_BY_SUITE:
+        return EXTRA_SOURCES_BY_SUITE[suite]
     if suite == "atomic":
         return [
             "avs/qemu/tests/07_atomic_lr_srczero.S",
@@ -576,6 +605,19 @@ EXTRA_LLCFLAGS_BY_SUITE: dict[str, list[str]] = {
 }
 
 OBJDUMP_ASSERTS_BY_SUITE: dict[str, list[str]] = {
+    "tile_v058_tlsu": [
+        r"\bBSTART\.TLOAD\b",
+        r"\b81 11 11 08\s+BSTART\.TSTORE\s+FP32\b",
+    ],
+    "tile_v058_vec": [
+        r"\bBSTART\.(?:VEC|TEPL)\s+TADD\b",
+    ],
+    "tile_v058_sfu": [
+        r"\bBSTART\.SFU\s+TEXP\b",
+    ],
+    "tile_v058_cube": [
+        r"\bBSTART\.TMATMUL\b",
+    ],
     "simt_autovec": [
         r"(?s)<search_store_index_grouped_boundary>:.*?\bBSTART\.MSEQ\b.*?\bB\.TEXT\b.*?B\.IOTI.*?B\.IOTI.*?C\.B\.DIMI\s+32,\s+->lb0.*?C\.B\.DIMI\s+2,\s+->lb1.*?\bv\.sw\.brg\.local\b.*?\bv\.lw\.brg\b.*?->p.*?\bb\.nz\b.*?\bj\b.*?\bv\.sw\.brg\b",
         r"(?s)<search_store_index_split_addrs_autovec>:.*?\bBSTART\.MSEQ\b.*?\bB\.TEXT\b.*?C\.B\.DIMI\s+32,\s+->lb0.*?C\.B\.DIMI\s+2,\s+->lb1.*?\bv\.psel\s+p,.*?\bv\.sw\.brg\b.*?\bv\.sw\.brg\b.*?\bv\.cmp\.ne\b",
@@ -597,6 +639,8 @@ OBJDUMP_ASSERTS_BY_SUITE: dict[str, list[str]] = {
         r"(?s)<sign_classify_i16_autovec>:.*?\bBSTART\.MSEQ\b.*?\bB\.TEXT\b.*?C\.B\.DIMI\s+32,\s+->lb0.*?C\.B\.DIMI\s+2,\s+->lb1.*?\bv\.lh\.brg\b.*?\bv\.cmp\.lt\b.*?\bv\.csel\b.*?\bv\.sw\.brg\b",
     ],
 }
+
+OBJDUMP_CARRIER_SUITES: set[str] = set(EXTRA_SOURCES_BY_SUITE)
 
 EXPERIMENTAL_SUITES: set[str] = {
     # v0.57 migration keeps this behind --all-suites until the vblock body
@@ -1239,6 +1283,16 @@ def main(argv: list[str]) -> int:
                 if meta["src"] == src_rel:
                     src_suite = suite_name
                     break
+        if src_suite is None:
+            try:
+                repo_rel = src.relative_to(REPO_ROOT).as_posix()
+            except ValueError:
+                repo_rel = None
+            if repo_rel is not None:
+                for suite_name, extra_sources in EXTRA_SOURCES_BY_SUITE.items():
+                    if repo_rel in extra_sources:
+                        src_suite = suite_name
+                        break
         if src_suite is not None:
             cflags.extend(EXTRA_CFLAGS_BY_SUITE.get(src_suite, []))
         tool = clang
@@ -1286,7 +1340,9 @@ def main(argv: list[str]) -> int:
         if src.suffix.lower() in {".s", ".S"}:
             sidecar = obj.with_suffix(src.suffix.lower())
             shutil.copyfile(src, sidecar)
-        if src_suite in OBJDUMP_ASSERTS_BY_SUITE:
+        if src_suite in OBJDUMP_ASSERTS_BY_SUITE and (
+            src_suite not in OBJDUMP_CARRIER_SUITES or src.name.endswith("_carrier.S")
+        ):
             _verify_objdump_shape(
                 llvm_objdump,
                 obj,

--- a/avs/qemu/tests/28_v058_tile_tlsu.c
+++ b/avs/qemu/tests/28_v058_tile_tlsu.c
@@ -1,0 +1,28 @@
+#include "linx_test.h"
+
+#include <stdint.h>
+
+enum { kElements = 1024 };
+static const uint32_t kTestId = 0x00002A01u;
+
+static int32_t input[kElements] __attribute__((aligned(64)));
+static int32_t output[kElements] __attribute__((aligned(64)));
+
+extern void linx_v058_tlsu_copy(const int32_t *src, int32_t *dst,
+                                uint64_t stride);
+
+void run_tile_v058_tlsu_tests(void)
+{
+    test_start(kTestId);
+    for (unsigned i = 0; i < kElements; ++i) {
+        input[i] = (int32_t)(i * 17u) - 4091;
+        output[i] = (int32_t)0x55555555u;
+    }
+
+    linx_v058_tlsu_copy(input, output, 32u);
+
+    for (unsigned i = 0; i < kElements; ++i) {
+        TEST_EQ32((uint32_t)output[i], (uint32_t)input[i], kTestId);
+    }
+    test_pass();
+}

--- a/avs/qemu/tests/28_v058_tile_tlsu_carrier.S
+++ b/avs/qemu/tests/28_v058_tile_tlsu_carrier.S
@@ -1,0 +1,18 @@
+    .text
+    .globl linx_v058_tlsu_copy
+    .type linx_v058_tlsu_copy,@function
+linx_v058_tlsu_copy:
+    FENTRY [ra ~ ra], sp!, 8
+    BSTART.TLOAD FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a0, a2]
+    B.IOT mask=1111, last, ->t<4KB>
+
+    BSTART.TSTORE FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a1, a2]
+    B.IOT t#1, mask=1111, last
+    FRET.STK [ra ~ ra], sp!, 8
+    .size linx_v058_tlsu_copy, .-linx_v058_tlsu_copy

--- a/avs/qemu/tests/29_v058_tile_vec.c
+++ b/avs/qemu/tests/29_v058_tile_vec.c
@@ -1,0 +1,30 @@
+#include "linx_test.h"
+
+#include <stdint.h>
+
+enum { kElements = 1024 };
+static const uint32_t kTestId = 0x00002B01u;
+
+static uint32_t lhs[kElements] __attribute__((aligned(64)));
+static uint32_t rhs[kElements] __attribute__((aligned(64)));
+static uint32_t output[kElements] __attribute__((aligned(64)));
+
+extern void linx_v058_vec_add(const uint32_t *a, const uint32_t *b,
+                              uint32_t *dst, uint64_t stride);
+
+void run_tile_v058_vec_tests(void)
+{
+    test_start(kTestId);
+    for (unsigned i = 0; i < kElements; ++i) {
+        lhs[i] = 0x3F800000u;
+        rhs[i] = 0x40000000u;
+        output[i] = 0x55555555u;
+    }
+
+    linx_v058_vec_add(lhs, rhs, output, 32u);
+
+    for (unsigned i = 0; i < kElements; ++i) {
+        TEST_EQ32(output[i], 0x40400000u, kTestId);
+    }
+    test_pass();
+}

--- a/avs/qemu/tests/29_v058_tile_vec_carrier.S
+++ b/avs/qemu/tests/29_v058_tile_vec_carrier.S
@@ -1,0 +1,29 @@
+    .text
+    .globl linx_v058_vec_add
+    .type linx_v058_vec_add,@function
+linx_v058_vec_add:
+    FENTRY [ra ~ ra], sp!, 8
+    BSTART.TLOAD FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a0, a3]
+    B.IOT mask=1111, last, ->t<4KB>
+
+    BSTART.TLOAD FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a1, a3]
+    B.IOT mask=1111, last, ->t<4KB>
+
+    BSTART.VEC TADD, FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOT t#2, t#1, mask=1111, last, ->t<4KB>
+
+    BSTART.TSTORE FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a2, a3]
+    B.IOT t#1, mask=1111, last
+    FRET.STK [ra ~ ra], sp!, 8
+    .size linx_v058_vec_add, .-linx_v058_vec_add

--- a/avs/qemu/tests/30_v058_tile_sfu.c
+++ b/avs/qemu/tests/30_v058_tile_sfu.c
@@ -1,0 +1,28 @@
+#include "linx_test.h"
+
+#include <stdint.h>
+
+enum { kElements = 1024 };
+static const uint32_t kTestId = 0x00002C01u;
+
+static uint32_t input[kElements] __attribute__((aligned(64)));
+static uint32_t output[kElements] __attribute__((aligned(64)));
+
+extern void linx_v058_sfu_exp(const uint32_t *src, uint32_t *dst,
+                              uint64_t stride);
+
+void run_tile_v058_sfu_tests(void)
+{
+    test_start(kTestId);
+    for (unsigned i = 0; i < kElements; ++i) {
+        input[i] = 0x00000000u;
+        output[i] = 0xBF800000u;
+    }
+
+    linx_v058_sfu_exp(input, output, 32u);
+
+    for (unsigned i = 0; i < kElements; ++i) {
+        TEST_EQ32(output[i], 0x3F800000u, kTestId);
+    }
+    test_pass();
+}

--- a/avs/qemu/tests/30_v058_tile_sfu_carrier.S
+++ b/avs/qemu/tests/30_v058_tile_sfu_carrier.S
@@ -1,0 +1,23 @@
+    .text
+    .globl linx_v058_sfu_exp
+    .type linx_v058_sfu_exp,@function
+linx_v058_sfu_exp:
+    FENTRY [ra ~ ra], sp!, 8
+    BSTART.TLOAD FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a0, a2]
+    B.IOT mask=1111, last, ->t<4KB>
+
+    BSTART.SFU TEXP, FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOT t#1, mask=1111, last, ->t<4KB>
+
+    BSTART.TSTORE FP32
+    C.B.DIMI 32, ->lb0
+    C.B.DIMI 32, ->lb1
+    B.IOR [a1, a2]
+    B.IOT t#1, mask=1111, last
+    FRET.STK [ra ~ ra], sp!, 8
+    .size linx_v058_sfu_exp, .-linx_v058_sfu_exp

--- a/avs/qemu/tests/31_v058_tile_cube.c
+++ b/avs/qemu/tests/31_v058_tile_cube.c
@@ -1,0 +1,37 @@
+#include "linx_test.h"
+
+#include <stdint.h>
+
+enum { kDim = 4, kTileElements = 1024 };
+static const uint32_t kTestId = 0x00002D01u;
+
+static uint32_t lhs[kTileElements] __attribute__((aligned(64)));
+static uint32_t rhs[kTileElements] __attribute__((aligned(64)));
+static uint32_t output[kTileElements] __attribute__((aligned(64)));
+
+extern void linx_v058_cube_matmul(const uint32_t *a, const uint32_t *b,
+                                  uint32_t *dst, uint64_t stride);
+
+void run_tile_v058_cube_tests(void)
+{
+    test_start(kTestId);
+    for (unsigned i = 0; i < kTileElements; ++i) {
+        lhs[i] = 0u;
+        rhs[i] = 0u;
+        output[i] = 0xBF800000u;
+    }
+    for (unsigned row = 0; row < kDim; ++row) {
+        for (unsigned col = 0; col < kDim; ++col) {
+            const unsigned index = row * kDim + col;
+            lhs[index] = row == col ? 1u : 0u;
+            rhs[index] = row * kDim + col + 1u;
+        }
+    }
+
+    linx_v058_cube_matmul(lhs, rhs, output, 4u);
+
+    for (unsigned i = 0; i < kDim * kDim; ++i) {
+        TEST_EQ32(output[i], rhs[i], kTestId);
+    }
+    test_pass();
+}

--- a/avs/qemu/tests/31_v058_tile_cube_carrier.S
+++ b/avs/qemu/tests/31_v058_tile_cube_carrier.S
@@ -1,0 +1,30 @@
+    .text
+    .globl linx_v058_cube_matmul
+    .type linx_v058_cube_matmul,@function
+linx_v058_cube_matmul:
+    FENTRY [ra ~ ra], sp!, 8
+    BSTART.TLOAD S32
+    C.B.DIMI 4, ->lb0
+    C.B.DIMI 4, ->lb1
+    B.IOR [a0, a3]
+    B.IOT mask=1111, last, ->t<4KB>
+
+    BSTART.TLOAD S32
+    C.B.DIMI 4, ->lb0
+    C.B.DIMI 4, ->lb1
+    B.IOR [a1, a3]
+    B.IOT mask=1111, last, ->t<4KB>
+
+    BSTART.TMATMUL S32
+    C.B.DIMI 4, ->lb0
+    C.B.DIMI 4, ->lb1
+    C.B.DIMI 4, ->lb2
+    B.IOT t#2, t#1, mask=1111, last, ->m<128B>
+
+    BSTART.TSTORE S32
+    C.B.DIMI 4, ->lb0
+    C.B.DIMI 4, ->lb1
+    B.IOR [a2, a3]
+    B.IOT m#1, mask=1111, last
+    FRET.STK [ra ~ ra], sp!, 8
+    .size linx_v058_cube_matmul, .-linx_v058_cube_matmul

--- a/avs/qemu/tests/main.c
+++ b/avs/qemu/tests/main.c
@@ -65,6 +65,18 @@
 #ifndef LINX_TEST_ENABLE_MADDW_BFI_MI
 #define LINX_TEST_ENABLE_MADDW_BFI_MI 0
 #endif
+#ifndef LINX_TEST_ENABLE_TILE_V058_TLSU
+#define LINX_TEST_ENABLE_TILE_V058_TLSU 0
+#endif
+#ifndef LINX_TEST_ENABLE_TILE_V058_VEC
+#define LINX_TEST_ENABLE_TILE_V058_VEC 0
+#endif
+#ifndef LINX_TEST_ENABLE_TILE_V058_SFU
+#define LINX_TEST_ENABLE_TILE_V058_SFU 0
+#endif
+#ifndef LINX_TEST_ENABLE_TILE_V058_CUBE
+#define LINX_TEST_ENABLE_TILE_V058_CUBE 0
+#endif
 
 /* Forward declarations for test suite functions */
 #if LINX_TEST_ENABLE_ARITHMETIC
@@ -123,6 +135,18 @@ void run_setc_imm_tests(void);
 #endif
 #if LINX_TEST_ENABLE_MADDW_BFI_MI
 void run_maddw_bfi_mi_tests(void);
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_TLSU
+void run_tile_v058_tlsu_tests(void);
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_VEC
+void run_tile_v058_vec_tests(void);
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_SFU
+void run_tile_v058_sfu_tests(void);
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_CUBE
+void run_tile_v058_cube_tests(void);
 #endif
 
 /*
@@ -187,6 +211,18 @@ void _start(void) {
 #endif
 #if LINX_TEST_ENABLE_MADDW_BFI_MI
     run_maddw_bfi_mi_tests();
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_TLSU
+    run_tile_v058_tlsu_tests();
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_VEC
+    run_tile_v058_vec_tests();
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_SFU
+    run_tile_v058_sfu_tests();
+#endif
+#if LINX_TEST_ENABLE_TILE_V058_CUBE
+    run_tile_v058_cube_tests();
 #endif
 #if LINX_TEST_ENABLE_SYSTEM
     /* This suite exits through its final trap continuation; keep it last. */

--- a/tools/bringup/check_avs_contract.py
+++ b/tools/bringup/check_avs_contract.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Validate the canonical AVS matrix used as the public v0.57 bring-up contract.
+Validate the canonical AVS matrix used as the public v0.58 bring-up contract.
 """
 
 from __future__ import annotations
@@ -84,8 +84,8 @@ def main(argv: list[str]) -> int:
 
     data = _load_yaml_or_json(matrix_path)
     version = str(data.get("version", "")).strip()
-    if version != "linx-avs-v0.57":
-        raise SystemExit(f"error: matrix.version must be 'linx-avs-v0.57' (got {version!r})")
+    if version != "linx-avs-v0.58":
+        raise SystemExit(f"error: matrix.version must be 'linx-avs-v0.58' (got {version!r})")
     status = str(data.get("status", "")).strip()
     if status != "canonical":
         raise SystemExit(f"error: matrix.status must be 'canonical' (got {status!r})")

--- a/tools/bringup/check_avs_matrix_status.py
+++ b/tools/bringup/check_avs_matrix_status.py
@@ -91,9 +91,9 @@ def main(argv: list[str]) -> int:
     extra_status = sorted(status_set - matrix_set)
 
     schema_version = str(status_data.get("schema_version", "")).strip()
-    if schema_version != "linx-avs-v0.57-status-v1":
+    if schema_version != "linx-avs-v0.58-status-v1":
         print(
-            f"error: status JSON schema_version must be 'linx-avs-v0.57-status-v1' (got {schema_version!r})",
+            f"error: status JSON schema_version must be 'linx-avs-v0.58-status-v1' (got {schema_version!r})",
             file=sys.stderr,
         )
         return 1

--- a/tools/bringup/gen_avs_matrix_status.py
+++ b/tools/bringup/gen_avs_matrix_status.py
@@ -129,7 +129,7 @@ def main(argv: list[str]) -> int:
                     slot["pass"] += 1
 
     payload = {
-        "schema_version": "linx-avs-v0.57-status-v1",
+        "schema_version": "linx-avs-v0.58-status-v1",
         "generated_at_utc": _utc_now(),
         "matrix_file": str(Path(args.matrix)),
         "coverage_profile_summaries": coverage_profile_summaries,


### PR DESCRIPTION
## Summary

- update the canonical AVS matrix and status schema from v0.57 to v0.58
- add bounded QEMU runtime suites for the v0.58 TLSU, VEC, SFU, and CUBE engines
- use canonical assembly carriers plus independent freestanding C oracles
- add raw-byte gating for the TLSU Local TSTORE Function 1 encoding
- document the v0.58 AVS commands, evidence, and frontend boundary

## Verification

- `python3 -m unittest avs/qemu/test_run_tests.py` (18/18)
- LinxISA LLVM MC tests: 47 discovered, no failures
- four-engine compile-only gate: PASS
- four-engine QEMU runtime: PASS
  - `0x00002a01`, `0x00002b01`, `0x00002c01`, `0x00002d01`: START/PASS
  - independent oracle: PASS
  - `exit_code=0`, `stalled=false`, `timed_out=false`
- `tools/bringup/check_avs_contract.py`: PASS
- `tools/bringup/check_avs_matrix_status.py`: PASS
- `tools/bringup/check_avs_profile_closure.py --tier pr`: PASS

The LLVM assembler tie-break implementation itself is intentionally not part of this superproject PR; it remains in the LLVM submodule worktree for a separate upstream issue.
