### PR TITLE
fix: repin linx-model codec projection in #191

### DIFF
--- a/docs/bringup/component-lock.v0.58.json
+++ b/docs/bringup/component-lock.v0.58.json
@@ -136,10 +136,10 @@
       "path": "tools/model",
       "url": "https://github.com/LinxISA/linx-model.git",
       "branch": "main",
-      "commit": "bf9d73cff60009e9d40e7f3d240411d96af8cf87",
-      "tree": "e1cfb2ff41916573752ba192b38d33ee7bcc8c76",
+      "commit": "e9f14d9228732f0589f309285cbc8aabaa698353",
+      "tree": "970ca59157a53349d2ccd75d942526f007df7acc",
       "release": "0.58.3",
-      "role": "v0.58.3 queue-wired model"
+      "role": "v0.58.5 codec projection model"
     },
     {
       "path": "tools/pyCircuit",


### PR DESCRIPTION
This is a small dependent PR for LinxISA/linx-isa#191.

The #191 model job currently initializes `tools/model` at `bf9d73c`, whose committed codec catalog is stale relative to the checked-in authority and causes `linx_model_check_gen_minst_codec` to fail (catalog hash/count and authority-mutation assertions). The validated codec projection is in LinxISA/linx-model#19 at `e9f14d9228732f0589f309285cbc8aabaa698353` (tree `970ca59157a53349d2ccd75d942526f007df7acc`).

This PR updates the `tools/model` gitlink and component lock together. It deliberately does not change the functional-model chain or bypass any guard.

Merge this into #191 (or cherry-pick commit `520c25cdf51ea5c9639e5922f20cc95790208b1f`) after #19 is accepted.
