### PR TITLE
ci: authenticate private SuperScalarModel checkout in #191

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,18 @@ jobs:
       - name: Initialize canonical QEMU leaf
         run: git submodule update --init emulator/qemu
       - name: Initialize PTO ASL functional-model chain
+        env:
+          SUPERSCALARMODEL_READ_TOKEN: ${{ secrets.SUPERSCALARMODEL_READ_TOKEN }}
         run: |
+          if [[ -z "$SUPERSCALARMODEL_READ_TOKEN" ]]; then
+            echo "SUPERSCALARMODEL_READ_TOKEN is required to read the private SuperScalarModel submodule" >&2
+            exit 1
+          fi
+          git config --local url."https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/".insteadOf "https://github.com/"
+          cleanup_credentials() {
+            git config --local --unset-all "url.https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/.insteadOf" || true
+          }
+          trap cleanup_credentials EXIT
           git submodule update --init tools/pto-spec
           git submodule update --init tools/asl-model
           git submodule update --init tools/SuperScalarModel

--- a/.github/workflows/functional-model.yml
+++ b/.github/workflows/functional-model.yml
@@ -27,7 +27,18 @@ jobs:
         with:
           python-version: "3.11"
       - name: Initialize exact functional-model components
+        env:
+          SUPERSCALARMODEL_READ_TOKEN: ${{ secrets.SUPERSCALARMODEL_READ_TOKEN }}
         run: |
+          if [[ -z "$SUPERSCALARMODEL_READ_TOKEN" ]]; then
+            echo "SUPERSCALARMODEL_READ_TOKEN is required to read the private SuperScalarModel submodule" >&2
+            exit 1
+          fi
+          git config --local url."https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/".insteadOf "https://github.com/"
+          cleanup_credentials() {
+            git config --local --unset-all "url.https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/.insteadOf" || true
+          }
+          trap cleanup_credentials EXIT
           git submodule update --init tools/pto-spec
           git submodule update --init tools/asl-model
           git submodule update --init tools/SuperScalarModel

--- a/docs/bringup/FUNCTIONAL_MODEL_CI_SECURITY.md
+++ b/docs/bringup/FUNCTIONAL_MODEL_CI_SECURITY.md
@@ -20,3 +20,11 @@ remains unsatisfied. To obtain the check, a maintainer must mirror the exact
 fork head commit to a trusted branch in the base repository, or use a
 separately authorized ephemeral runner lane. Labels and secrets are not runner
 authorization mechanisms.
+
+The `tools/SuperScalarModel` gitlink is hosted in a private repository. The
+repository must provide both workflows with a read-only GitHub App or
+fine-grained token in the `SUPERSCALARMODEL_READ_TOKEN` secret. Restrict the
+token to `LinxISA/SuperScalarModel` contents read access. The workflows use it
+only while initializing submodules and remove the temporary URL rewrite when
+that step exits. Without this secret, the guards job fails during submodule
+initialization before it can report lock or projection results.


### PR DESCRIPTION
This dependent PR addresses the concrete `guards` failure in LinxISA/linx-isa#191.

`tools/SuperScalarModel` is a private submodule. GitHub-hosted CI currently uses the default `GITHUB_TOKEN`, which is scoped to `LinxISA/linx-isa`; `git submodule update --init tools/SuperScalarModel` therefore fails with `could not read Username for https://github.com` before lock validation runs.

The workflows now consume `SUPERSCALARMODEL_READ_TOKEN`, a repository secret that should contain a read-only GitHub App/fine-grained token restricted to `LinxISA/SuperScalarModel`. The token is used only for the submodule initialization step and the temporary URL rewrite is removed on exit. Missing configuration fails with a direct actionable message.

This does not alter the submodule URL, lock identity, trusted-push policy, or permit untrusted fork code to trigger the execution-backed workflow. Configure the secret in the base repository before enabling the dependent PR.

Base: LinxISA/linx-isa#191
