### PR TITLE
fix: complete model pin and private checkout setup for #191

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,18 @@ jobs:
       - name: Initialize canonical QEMU leaf
         run: git submodule update --init emulator/qemu
       - name: Initialize PTO ASL functional-model chain
+        env:
+          SUPERSCALARMODEL_READ_TOKEN: ${{ secrets.SUPERSCALARMODEL_READ_TOKEN }}
         run: |
+          if [[ -z "$SUPERSCALARMODEL_READ_TOKEN" ]]; then
+            echo "SUPERSCALARMODEL_READ_TOKEN is required to read the private SuperScalarModel submodule" >&2
+            exit 1
+          fi
+          git config --local url."https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/".insteadOf "https://github.com/"
+          cleanup_credentials() {
+            git config --local --unset-all "url.https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/.insteadOf" || true
+          }
+          trap cleanup_credentials EXIT
           git submodule update --init tools/pto-spec
           git submodule update --init tools/asl-model
           git submodule update --init tools/SuperScalarModel
@@ -193,10 +204,19 @@ jobs:
         run: |
           git submodule sync -- tools/model
           git submodule update --init tools/model
+      - name: Check out immutable LinxISA codec authority
+        uses: actions/checkout@v7
+        with:
+          repository: LinxISA/linx-isa
+          ref: 660c870ff241f9803d8060f00ed3684ffed6f06c
+          path: .ci/linxisa-codec-authority
+          fetch-depth: 1
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y ninja-build
       - name: Configure tools/model
-        run: cmake -S tools/model -B tools/model/build-ci -G Ninja
+        run: >-
+          cmake -S tools/model -B tools/model/build-ci -G Ninja
+          -DLINXISA_AUTHORITY_ROOT="${{ github.workspace }}/.ci/linxisa-codec-authority"
       - name: Build tools/model
         run: cmake --build tools/model/build-ci
       - name: Run tools/model tests

--- a/.github/workflows/functional-model.yml
+++ b/.github/workflows/functional-model.yml
@@ -27,7 +27,18 @@ jobs:
         with:
           python-version: "3.11"
       - name: Initialize exact functional-model components
+        env:
+          SUPERSCALARMODEL_READ_TOKEN: ${{ secrets.SUPERSCALARMODEL_READ_TOKEN }}
         run: |
+          if [[ -z "$SUPERSCALARMODEL_READ_TOKEN" ]]; then
+            echo "SUPERSCALARMODEL_READ_TOKEN is required to read the private SuperScalarModel submodule" >&2
+            exit 1
+          fi
+          git config --local url."https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/".insteadOf "https://github.com/"
+          cleanup_credentials() {
+            git config --local --unset-all "url.https://x-access-token:${SUPERSCALARMODEL_READ_TOKEN}@github.com/.insteadOf" || true
+          }
+          trap cleanup_credentials EXIT
           git submodule update --init tools/pto-spec
           git submodule update --init tools/asl-model
           git submodule update --init tools/SuperScalarModel

--- a/docs/bringup/FUNCTIONAL_MODEL_CI_SECURITY.md
+++ b/docs/bringup/FUNCTIONAL_MODEL_CI_SECURITY.md
@@ -20,3 +20,11 @@ remains unsatisfied. To obtain the check, a maintainer must mirror the exact
 fork head commit to a trusted branch in the base repository, or use a
 separately authorized ephemeral runner lane. Labels and secrets are not runner
 authorization mechanisms.
+
+The `tools/SuperScalarModel` gitlink is hosted in a private repository. The
+repository must provide both workflows with a read-only GitHub App or
+fine-grained token in the `SUPERSCALARMODEL_READ_TOKEN` secret. Restrict the
+token to `LinxISA/SuperScalarModel` contents read access. The workflows use it
+only while initializing submodules and remove the temporary URL rewrite when
+that step exits. Without this secret, the guards job fails during submodule
+initialization before it can report lock or projection results.

--- a/docs/bringup/component-lock.v0.58.json
+++ b/docs/bringup/component-lock.v0.58.json
@@ -136,10 +136,10 @@
       "path": "tools/model",
       "url": "https://github.com/LinxISA/linx-model.git",
       "branch": "main",
-      "commit": "bf9d73cff60009e9d40e7f3d240411d96af8cf87",
-      "tree": "e1cfb2ff41916573752ba192b38d33ee7bcc8c76",
+      "commit": "e9f14d9228732f0589f309285cbc8aabaa698353",
+      "tree": "970ca59157a53349d2ccd75d942526f007df7acc",
       "release": "0.58.3",
-      "role": "v0.58.3 queue-wired model"
+      "role": "v0.58.5 codec projection model"
     },
     {
       "path": "tools/pyCircuit",


### PR DESCRIPTION
This is the consolidated dependent fix for LinxISA/linx-isa#191.

It addresses both observed failures without weakening any guard:

1. Pin `tools/model` to LinxISA/linx-model#19 (`e9f14d9228732f0589f309285cbc8aabaa698353`) and update `component-lock.v0.58.json` atomically.
2. Make the `model` job run the codec freshness tests against the immutable v0.58.5 LinxISA authority (`660c870ff241f9803d8060f00ed3684ffed6f06c`) instead of the superproject's projection, which is intentionally not the codec authority.
3. Make both workflows authenticate the private `tools/SuperScalarModel` submodule with the least-privilege `SUPERSCALARMODEL_READ_TOKEN` secret and document the required repository configuration.

The submodule URL, functional-model lock identity, push-only execution policy, and fail-closed behavior are unchanged. This PR does not add a fallback or bypass a test. Configure `SUPERSCALARMODEL_READ_TOKEN` in the base repository before expecting the guards job to initialize the private consumer.

Base: LinxISA/linx-isa#191
Related superseded dependent PRs: #194 and #195.
